### PR TITLE
docs: add Russian usage guide

### DIFF
--- a/как_это_работает.md
+++ b/как_это_работает.md
@@ -1,0 +1,632 @@
+# Как это работает
+
+`codex-spec` — инструмент, помогающий вести разработку на основе спецификаций. Ниже описан рекомендуемый процесс работы и исходные промпты, которые используются для генерации спецификаций, требований, планов и выполнения задач. Для удобства приведены оригинальные английские тексты и их перевод на русский язык.
+
+## 1. Настройка контекста проекта
+
+### Команда
+```bash
+codex-spec context-setup [--force]
+```
+Создаёт файлы контекста продукта, техники и структуры проекта в директории `.codex-specs/context` и обновляет `AGENTS.md`.
+
+### Промпты
+
+#### Анализ существующего кода
+Английский текст:
+```text
+Analyze the current codebase structure and provide a comprehensive overview:
+
+1. **Technology Stack**: Programming languages, frameworks, libraries detected
+2. **Architecture Pattern**: MVC, microservices, monolith, serverless, etc.
+3. **Key Components**: Main modules, services, or components identified
+4. **API Endpoints**: REST routes, GraphQL resolvers, or RPC methods found
+5. **Database/Storage**: Data persistence patterns and technologies detected
+6. **Build/Deploy**: Build tools, CI/CD configuration, deployment setup
+7. **Testing**: Testing frameworks and current test coverage approach
+8. **Dependencies**: Major external dependencies and their purposes
+
+Focus on factual observations from the codebase structure, configuration files, and package definitions.
+```
+Перевод:
+```text
+Проанализируй структуру текущей кодовой базы и предоставь развёрнутый обзор:
+
+1. **Технологический стек**: используемые языки программирования, фреймворки, библиотеки
+2. **Архитектурный паттерн**: MVC, микросервисы, монолит, serverless и т.д.
+3. **Ключевые компоненты**: основные модули, сервисы или компоненты
+4. **API эндпоинты**: REST‑маршруты, GraphQL‑резолверы или RPC‑методы
+5. **База данных/хранилище**: способы хранения данных и используемые технологии
+6. **Сборка/деплой**: инструменты сборки, конфигурация CI/CD, настройка деплоя
+7. **Тестирование**: используемые фреймворки и текущий подход к покрытию тестами
+8. **Зависимости**: основные внешние зависимости и их назначение
+
+Сосредоточься на фактических наблюдениях по структуре кода, конфигурационным файлам и описаниям пакетов.
+```
+
+#### Генерация контекста продукта
+Английский текст:
+```text
+Create product context documentation for project "${projectName}".
+
+## Project Summary
+- Description: ${projectDescription}
+- Type: ${projectType}
+- Target Users: ${targetUsers}
+- Key Features: ${keyFeatures}
+
+## Consider Existing Codebase (if any)
+${codebaseAnalysis}
+
+Please produce a markdown document covering:
+- Product Vision and Value Proposition
+- Primary Personas and Goals
+- User Journeys
+- High-level Features and Priorities
+- Success Metrics / KPIs
+```
+Перевод:
+```text
+Создай документацию по контексту продукта для проекта "${projectName}".
+
+## Краткое описание проекта
+- Описание: ${projectDescription}
+- Тип: ${projectType}
+- Целевая аудитория: ${targetUsers}
+- Ключевые функции: ${keyFeatures}
+
+## Учитывай существующую кодовую базу (если есть)
+${codebaseAnalysis}
+
+Подготовь markdown‑документ, включающий:
+- Видение продукта и ценностное предложение
+- Основные персоны и их цели
+- Пользовательские пути
+- Основные функции и приоритеты
+- Показатели успеха / KPI
+```
+
+#### Генерация технического контекста
+Английский текст:
+```text
+Create technical context documentation for the project.
+
+## Existing Tech Stack
+${techStack}
+
+## Observed Codebase (if any)
+${codebaseAnalysis}
+
+Please produce a markdown document covering:
+- System Architecture and key components
+- Technology decisions and rationale
+- Coding standards and conventions
+- Error handling, logging, and observability
+- Testing strategy and tooling
+- Security and performance considerations
+```
+Перевод:
+```text
+Создай документацию по техническому контексту проекта.
+
+## Текущий стек технологий
+${techStack}
+
+## Наблюдаемая кодовая база (если есть)
+${codebaseAnalysis}
+
+Подготовь markdown‑документ, включающий:
+- Архитектуру системы и ключевые компоненты
+- Выбор технологий и его обоснование
+- Стандарты и соглашения кодирования
+- Обработку ошибок, логирование и наблюдаемость
+- Стратегию тестирования и используемые инструменты
+- Вопросы безопасности и производительности
+```
+
+#### Генерация контекста структуры
+Английский текст:
+```text
+Document the project structure and workflows for "${projectName}".
+
+## Observed Structure (if any)
+${codebaseAnalysis}
+
+Please include:
+- Repository layout and directory purpose
+- Branching strategy and commit conventions
+- Build/test scripts and CI/CD outline
+- Development workflows (how to run, test, lint, type-check)
+- Contribution guidelines highlights
+```
+Перевод:
+```text
+Задокументируй структуру проекта и рабочие процессы для "${projectName}".
+
+## Наблюдаемая структура (если есть)
+${codebaseAnalysis}
+
+Включи:
+- Структуру репозитория и назначение директорий
+- Стратегию ветвления и соглашения по коммитам
+- Скрипты сборки/тестирования и схему CI/CD
+- Рабочие процессы разработки (как запускать, тестировать, линтить, проверять типы)
+- Основные положения руководства по внесению изменений
+```
+
+## 2. Обновление и обновление контекста
+
+### Команды
+```bash
+codex-spec context-update [product|tech|structure] [--auto]
+codex-spec context-refresh
+```
+`context-update` пересоздаёт выбранные файлы контекста, при `--auto` учитывает `git diff`. `context-refresh` полностью пересобирает весь контекст.
+
+### Дополнительные системные сообщения
+- `Update the product context reflecting recent changes.` — «Обнови контекст продукта с учётом последних изменений.»
+- `Update the technical context reflecting recent changes.` — «Обнови технический контекст с учётом последних изменений.»
+- `Update the structure context reflecting recent changes.` — «Обнови контекст структуры с учётом последних изменений.»
+- `Produce complete, current product context.` — «Сформируй полный и актуальный контекст продукта.»
+- `Produce complete, current technical context.` — «Сформируй полный и актуальный технический контекст.»
+- `Produce complete, current structure context.` — «Сформируй полный и актуальный контекст структуры.»
+
+## 3. Создание спецификации
+
+### Команда
+```bash
+codex-spec create "Название фичи" ["Описание"] [--title slug]
+```
+Генерирует спецификацию и файл `AGENTS.md` для новой фичи.
+
+### Промпты
+
+#### Генерация slug директории
+Английский текст:
+```text
+Generate a concise, clear snake_case slug (3-6 words) for this feature. Letters, numbers, and underscores only. No prefix/suffix.
+
+Feature: ${featureName}
+```
+Перевод:
+```text
+Сгенерируй краткий и понятный slug в формате snake_case (3–6 слов) для этой фичи. Допустимы только буквы, цифры и подчёркивания. Без префиксов и суффиксов.
+
+Фича: ${featureName}
+```
+
+#### Создание спецификации
+Английский текст:
+```text
+Create a comprehensive specification for: ${featureName}
+
+Description: ${description}
+
+Please provide a detailed specification with the following structure:
+
+## 1. Feature Overview
+- Brief summary of the feature and its purpose
+- Business value and objectives
+- Success metrics and KPIs
+
+## 2. User Stories & Personas
+- Primary user personas who will use this feature
+- User stories in the format: "As a [user], I want [goal] so that [benefit]"
+- User journey and interaction flow
+
+## 3. Functional Requirements
+- Core functionality requirements
+- User interface requirements
+- Business logic requirements
+- Integration requirements
+
+## 4. Acceptance Criteria (EARS Format)
+Use WHEN/IF/THEN format for testable criteria:
+- WHEN [trigger condition] THEN [expected outcome]
+- IF [condition] THEN [system behavior]
+- Include edge cases and error scenarios
+
+## 5. Non-Functional Requirements
+- Performance requirements (response time, throughput)
+- Security requirements
+- Accessibility requirements
+- Browser/platform compatibility
+
+## 6. Technical Considerations
+- Integration points with existing systems
+- Dependencies on other features or services
+- Data requirements and constraints
+- API requirements
+
+## 7. Testing Strategy
+- Unit test requirements
+- Integration test scenarios
+- User acceptance test cases
+- Performance test criteria
+
+Format as clean markdown with clear sections and actionable requirements.
+```
+Перевод:
+```text
+Создай подробную спецификацию для: ${featureName}
+
+Описание: ${description}
+
+Предоставь развёрнутую спецификацию со следующей структурой:
+
+## 1. Обзор фичи
+- Краткое описание и назначение
+- Бизнес‑ценность и цели
+- Метрики успеха и KPI
+
+## 2. Пользовательские истории и персоны
+- Основные персоны, которые будут использовать фичу
+- Пользовательские истории в формате: «Как [пользователь] я хочу [цель], чтобы [выгода]»
+- Путь пользователя и сценарий взаимодействия
+
+## 3. Функциональные требования
+- Основные функциональные требования
+- Требования к пользовательскому интерфейсу
+- Требования бизнес‑логики
+- Требования по интеграции
+
+## 4. Критерии приёмки (формат EARS)
+Используй формат WHEN/IF/THEN для проверяемых критериев:
+- WHEN [условие запуска] THEN [ожидаемый результат]
+- IF [условие] THEN [поведение системы]
+- Учитывай крайние случаи и ошибки
+
+## 5. Нефункциональные требования
+- Требования к производительности (время ответа, пропускная способность)
+- Требования безопасности
+- Требования доступности
+- Совместимость с браузерами/платформами
+
+## 6. Технические аспекты
+- Точки интеграции с существующими системами
+- Зависимости от других фич или сервисов
+- Требования к данным и ограничения
+- Требования к API
+
+## 7. Стратегия тестирования
+- Требования к модульным тестам
+- Сценарии интеграционного тестирования
+- Тесты приёмки пользователей
+- Критерии производительности
+
+Оформи в виде чистого markdown с чёткими разделами и конкретными требованиями.
+```
+
+### Системное сообщение
+`You are a senior product engineer writing precise, actionable specifications.` — «Ты опытный продуктовый инженер, пишущий точные и выполнимые спецификации.»
+
+## 4. Генерация требований
+
+### Команда
+```bash
+codex-spec requirements [spec-dir]
+```
+Создаёт `requirements.md` на основе спецификации.
+
+### Промпт
+Английский текст:
+```text
+Generate a detailed requirements document based on this feature specification:
+
+${specification}
+
+Please produce a markdown document with:
+- Functional requirements broken down by capability
+- Detailed business rules and edge cases
+- Acceptance criteria in EARS (WHEN/IF/THEN) format
+- Non-functional requirements (performance, security, accessibility)
+- Traceability: map requirements back to user stories
+```
+Перевод:
+```text
+Сгенерируй подробный документ требований на основе этой спецификации:
+
+${specification}
+
+Подготовь markdown‑документ со следующим содержимым:
+- Функциональные требования, разбитые по возможностям
+- Детальные бизнес‑правила и крайние случаи
+- Критерии приёмки в формате EARS (WHEN/IF/THEN)
+- Нефункциональные требования (производительность, безопасность, доступность)
+- Трассируемость: сопоставь требования с пользовательскими историями
+```
+
+### Системное сообщение
+`You are a business analyst producing precise, testable software requirements.` — «Ты бизнес‑аналитик, создающий точные и проверяемые программные требования.»
+
+## 5. Создание плана и задач
+
+### Команда
+```bash
+codex-spec plan [spec-dir]
+```
+Формирует `plan.md` и извлекает задачи в `tasks.json`.
+
+### Промпты
+
+#### Создание плана реализации
+Английский текст:
+```text
+Create a comprehensive implementation plan based on this specification and requirements:
+
+${projectContext}
+
+## Feature Specification
+${specification}
+
+## Detailed Requirements
+${requirements}
+
+Please provide a detailed implementation plan with the following structure:
+
+## 1. Technical Architecture
+- Overall system design approach that aligns with existing project architecture
+- Key components and their relationships
+- Data flow and architecture patterns
+- Technology stack decisions and rationale
+- Integration strategy with existing systems
+
+## 2. Implementation Strategy
+- Development phases (Foundation, Core Features, Integration, Testing, Polish)
+- Risk assessment and mitigation strategies
+- Testing approach throughout development
+- Deployment and rollback strategy
+
+## 3. Detailed Task Breakdown by Phase
+
+For each phase, provide specific tasks with this format:
+
+### Phase: [Phase Name]
+**Goal:** [What this phase accomplishes]
+**Dependencies:** [What must be completed before this phase]
+
+#### Task: [task-id] - [Task Title]
+- **Description:** Clear, specific description of what needs to be implemented
+- **Files to create/modify:** Specific file paths and what changes are needed
+- **Dependencies:** Other task IDs that must be completed first
+- **Acceptance criteria:** Specific, testable criteria to verify completion
+- **Complexity:** Small (30min), Medium (2hrs), or Large (1 day)
+- **Technical notes:** Implementation hints, gotchas, constraints, or patterns to follow
+
+## 4. Integration Points
+- How new components connect with existing system
+- API contracts between modules
+- Data persistence and migration strategy
+- External service integrations
+
+## 5. Quality Assurance Strategy
+- Unit testing approach for each component
+- Integration testing strategy
+- Performance testing requirements
+- Security considerations and testing
+- Code review checkpoints
+
+## 6. Deployment Plan
+- Build and deployment steps
+- Environment configuration changes
+- Database migrations if needed
+- Monitoring and alerting setup
+
+Format as clean markdown with clear task sections that can be extracted programmatically.
+Each task should be atomic and completable independently.
+```
+Перевод:
+```text
+Создай подробный план реализации на основе этой спецификации и требований:
+
+${projectContext}
+
+## Спецификация фичи
+${specification}
+
+## Детализированные требования
+${requirements}
+
+Предоставь развёрнутый план реализации со следующей структурой:
+
+## 1. Техническая архитектура
+- Общий подход к архитектуре системы, согласованный с текущим проектом
+- Ключевые компоненты и их взаимосвязи
+- Потоки данных и архитектурные шаблоны
+- Выбор технологий и его обоснование
+- Стратегия интеграции с существующими системами
+
+## 2. Стратегия реализации
+- Фазы разработки (Foundation, Core Features, Integration, Testing, Polish)
+- Оценка рисков и стратегии их снижения
+- Подход к тестированию на протяжении разработки
+- Стратегия деплоя и отката
+
+## 3. Детальная разбивка задач по фазам
+
+Для каждой фазы укажи конкретные задачи в следующем формате:
+
+### Фаза: [название фазы]
+**Цель:** [что достигается в этой фазе]
+**Зависимости:** [что должно быть завершено до начала фазы]
+
+#### Задача: [task-id] — [название задачи]
+- **Описание:** чёткое описание того, что нужно реализовать
+- **Файлы для создания/изменения:** конкретные пути и требуемые изменения
+- **Зависимости:** идентификаторы задач, которые нужно выполнить заранее
+- **Критерии приёмки:** конкретные и проверяемые критерии завершения
+- **Сложность:** Small (30 мин), Medium (2 ч) или Large (1 день)
+- **Технические примечания:** подсказки, ограничения или паттерны реализации
+
+## 4. Точки интеграции
+- Как новые компоненты взаимодействуют с существующей системой
+- API‑контракты между модулями
+- Стратегия сохранения данных и миграций
+- Интеграция внешних сервисов
+
+## 5. Стратегия обеспечения качества
+- Подход к модульному тестированию для каждого компонента
+- Стратегия интеграционного тестирования
+- Требования к производительным тестам
+- Вопросы безопасности и соответствующее тестирование
+- Контрольные точки для код‑ревью
+
+## 6. План деплоя
+- Шаги сборки и развёртывания
+- Изменения конфигурации окружений
+- Необходимые миграции базы данных
+- Настройка мониторинга и оповещений
+
+Оформи в виде чистого markdown с чёткими секциями задач, которые можно программно извлечь. Каждая задача должна быть атомарной и выполняться независимо.
+```
+
+#### Извлечение задач
+Английский текст:
+```text
+Extract all tasks from this implementation plan and return as a JSON array.
+
+${plan}
+
+Return ONLY valid JSON in this exact format (no markdown, no explanations):
+[
+  {
+    "id": "task-1",
+    "title": "Task title exactly as written",
+    "description": "What needs to be implemented",
+    "files": ["src/file1.js", "src/file2.js"],
+    "dependencies": ["task-0"],
+    "acceptanceCriteria": ["Criterion 1", "Criterion 2"],
+    "phase": "Foundation",
+    "complexity": "Medium",
+    "technicalNotes": "Optional notes to guide implementation"
+  }
+]
+```
+Перевод:
+```text
+Извлеки все задачи из этого плана реализации и верни их в виде массива JSON.
+
+${plan}
+
+Верни ТОЛЬКО корректный JSON строго в следующем формате (без markdown и пояснений):
+[
+  {
+    "id": "task-1",
+    "title": "Название задачи как в тексте",
+    "description": "Что нужно реализовать",
+    "files": ["src/file1.js", "src/file2.js"],
+    "dependencies": ["task-0"],
+    "acceptanceCriteria": ["Критерий 1", "Критерий 2"],
+    "phase": "Foundation",
+    "complexity": "Medium",
+    "technicalNotes": "Дополнительные примечания по реализации"
+  }
+]
+```
+
+### Системные сообщения
+- `You are a technical architect creating detailed implementation plans. Focus on architecture, technical approach, and breaking down work into manageable tasks with clear phases.` — «Ты технический архитектор, создающий подробные планы реализации. Сфокусируйся на архитектуре, техническом подходе и разбивке работы на управляемые фазы.»
+- `Extract tasks from the implementation plan and return as valid JSON array. Each task should have: id, title, description, files, dependencies, acceptanceCriteria, phase, complexity.` — «Извлеки задачи из плана реализации и верни их в виде корректного массива JSON. Каждая задача должна содержать: id, title, description, files, dependencies, acceptanceCriteria, phase, complexity.»
+
+## 6. Просмотр списка задач
+```bash
+codex-spec tasks
+```
+Выводит идентификаторы, названия, фазу и статус задач. Отдельного промпта не использует.
+
+## 7. Выполнение задач
+
+### Команды
+```bash
+codex-spec execute <task-id> [--read-only]
+codex-spec execute-phase "Название фазы"
+```
+Запускает выполнение одной задачи или всех задач фазы. По умолчанию разрешена запись в рабочую директорию; `--read-only` выполняет предварительный просмотр.
+
+### Промпт выполнения
+Английский текст:
+```text
+Based on our implementation plan and this specific task:
+
+## Implementation Plan Context
+${plan}
+
+## Current Task Details
+**Task ID:** ${task.id}
+**Title:** ${task.title}
+**Phase:** ${task.phase}
+**Complexity:** ${task.complexity}
+
+**Description:**
+${task.description}
+
+**Files to create/modify:**
+${(task.files || []).join(', ')}
+
+**Dependencies completed:**
+${(task.dependencies || []).length > 0 ? task.dependencies.join(', ') : 'None'}
+
+**Acceptance Criteria:**
+${(task.acceptanceCriteria || []).map(criteria => `- ${criteria}`).join('\n')}
+
+## Implementation Instructions
+
+Please implement this task following these guidelines:
+1. **Architecture Alignment**: Follow the technical architecture defined in the plan
+2. **Code Standards**: Adhere to the project's coding standards in AGENTS.md
+3. **Testing**: Write tests as specified in the plan's QA strategy
+4. **Documentation**: Update relevant documentation and comments
+5. **Integration**: Consider integration points mentioned in the plan
+
+${task.technicalNotes ? `**Technical Notes:** ${task.technicalNotes}` : ''}
+
+Please provide a complete implementation with all necessary files, tests, and documentation updates.
+```
+Перевод:
+```text
+Исходя из нашего плана реализации и данной задачи:
+
+## Контекст плана реализации
+${plan}
+
+## Детали текущей задачи
+**ID задачи:** ${task.id}
+**Название:** ${task.title}
+**Фаза:** ${task.phase}
+**Сложность:** ${task.complexity}
+
+**Описание:**
+${task.description}
+
+**Файлы для создания/изменения:**
+${(task.files || []).join(', ')}
+
+**Выполненные зависимости:**
+${(task.dependencies || []).length > 0 ? task.dependencies.join(', ') : 'Нет'}
+
+**Критерии приёмки:**
+${(task.acceptanceCriteria || []).map(criteria => `- ${criteria}`).join('\n')}
+
+## Инструкции по реализации
+
+Выполни задачу, соблюдая следующие рекомендации:
+1. **Соответствие архитектуре**: следуй архитектуре, определённой в плане
+2. **Стандарты кода**: придерживайся стандартов из AGENTS.md
+3. **Тестирование**: пиши тесты согласно стратегии QA в плане
+4. **Документация**: обновляй соответствующую документацию и комментарии
+5. **Интеграция**: учитывай точки интеграции, указанные в плане
+
+${task.technicalNotes ? `**Технические заметки:** ${task.technicalNotes}` : ''}
+
+Предоставь полную реализацию со всеми необходимыми файлами, тестами и обновлениями документации.
+```
+
+## 8. Статус и краткое резюме плана
+```bash
+codex-spec status
+codex-spec plan-summary
+```
+Показывает прогресс выполнения задач и сводку по фазам. Эти команды не используют отдельные промпты.
+
+---
+Следуя описанному процессу и промптам, можно последовательно формировать контекст проекта, спецификацию, требования, план работ и выполнять задачи с учётом всей накопленной информации.


### PR DESCRIPTION
## Summary
- Add `как_это_работает.md` with a Russian walkthrough of the codex-spec workflow
- Document all CLI commands with their original English prompts and Russian translations

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68c524a0f3b8832da8944b1730541069